### PR TITLE
fix for Lucee5 render task function name conflict

### DIFF
--- a/RenderTask.cfc
+++ b/RenderTask.cfc
@@ -33,7 +33,7 @@
 
 	public boolean function run(required Event event) {
 
-		render(arguments.event.getProperties(), arguments.event.getResponse());
+		this.render(arguments.event.getProperties(), arguments.event.getResponse());
 
 		return true;
 	}


### PR DESCRIPTION
Lucee 5 seems to have it's own Render function which conflicts with yours.
Not using the keyword THIS would call Lucee's one instead of your class's function.
